### PR TITLE
add typing_extensions to run dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ outputs:
         - importlib_metadata
 
 about:
-  home: https://gitlab.com/python-devs/importlib_metadata
+  home: https://github.com/python/importlib_metadata
   license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 5c5a2720817414a6c41f0a49993908068243ae02c1635a228126519b509c8aed
 
 build:
-  number: 0
+  number: 1
   noarch: python
 
 outputs:
@@ -24,6 +24,7 @@ outputs:
         - setuptools_scm
       run:
         - python >=3.6
+        - typing_extensions >=3.6.4
         - zipp >=0.5
     test:
       requires:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Hi folks! Thanks for keeping the ship running.

Looks like addition of `typing_extensions` for pre-3.8 didn't get picked up, as the `pip check` ran under 3.9:

https://github.com/python/importlib_metadata/blame/6955586a940f6bfda0c662039f4c7b7cc0876c9e/setup.cfg#L22