### PR TITLE
Add Python < 3.8 selector to typing_extensions dep

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ outputs:
         - setuptools_scm
       run:
         - python >=3.6
-        - typing_extensions >=3.6.4 # [py<38]
+        - typing_extensions >=3.6.4  # [py<38]
         - zipp >=0.5
     test:
       requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 5c5a2720817414a6c41f0a49993908068243ae02c1635a228126519b509c8aed
 
 build:
-  number: 1
+  number: 2
   noarch: python
 
 outputs:
@@ -24,7 +24,7 @@ outputs:
         - setuptools_scm
       run:
         - python >=3.6
-        - typing_extensions >=3.6.4
+        - typing_extensions >=3.6.4 # [py<38]
         - zipp >=0.5
     test:
       requires:


### PR DESCRIPTION
The dependency is not needed on Python >= 3.8.
Cf. https://github.com/python/importlib_metadata/blob/v3.3.0/setup.cfg#L22.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Follow-up to #55.