### PR TITLE
Use `uv` to bootstrap, add tests with coverage

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,11 +31,21 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
-mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-%H-%M-%S)
-echo > /opt/conda/conda-meta/history
-micromamba install --root-prefix ~/.conda --prefix /opt/conda \
-    --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  rattler-build conda-forge-ci-setup=4 "conda-build>=24.1"
+curl -fsSL https://pixi.sh/install.sh | bash
+export PATH="~/.pixi/bin:$PATH"
+pushd "${FEEDSTOCK_ROOT}"
+arch=$(uname -m)
+if [[ "$arch" == "x86_64" ]]; then
+  arch="64"
+fi
+sed -i.bak -e "s/platforms = .*/platforms = [\"linux-${arch}\"]/" -e "s/# __PLATFORM_SPECIFIC_ENV__ =/docker-build-linux-$arch =/" pixi.toml
+echo "Creating environment"
+PIXI_CACHE_DIR=/opt/conda pixi install --environment docker-build-linux-$arch
+pixi list
+echo "Activating environment"
+eval "$(pixi shell-hook --environment docker-build-linux-$arch)"
+mv pixi.toml.bak pixi.toml
+popd
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc
@@ -48,9 +58,6 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
-if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${HOST_PLATFORM}" != linux-* ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
-    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --test skip"
-fi
 
 
 ( endgroup "Configuring conda" ) 2> /dev/null

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,18 +1,10 @@
 bot:
   automerge: true
-build_platform:
-  osx_arm64: osx_64
-conda_forge_output_validation: true
 github:
   branch_name: main
   tooling_branch_name: main
-provider:
-  linux: azure
-  linux_aarch64: azure
-  linux_ppc64le: azure
-  osx: azure
-  win: azure
 conda_build:
   pkg_format: '2'
-test: native_and_emulated
 conda_build_tool: rattler-build
+conda_forge_output_validation: true
+conda_install_tool: pixi

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,53 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: toml -*-
+
+#                             VVVVVV  minimum `pixi` version
+"$schema" = "https://pixi.sh/v0.36.0/schema/manifest/schema.json"
+
+[project]
+name = "importlib_metadata-feedstock"
+version = "3.48.1"  # conda-smithy version used to generate this file
+description = "Pixi configuration for conda-forge/importlib_metadata-feedstock"
+authors = ["@conda-forge/importlib_metadata"]
+channels = ["conda-forge"]
+platforms = ["linux-64", "osx-64", "win-64"]
+
+[dependencies]
+conda-build = ">=24.1"
+conda-forge-ci-setup = "4.*"
+rattler-build = "*"
+
+[tasks]
+[tasks.inspect-all]
+cmd = "inspect_artifacts --all-packages"
+description = "List contents of all packages found in rattler-build build directory."
+[tasks.build]
+cmd = "rattler-build build --recipe recipe"
+description = "Build importlib_metadata-feedstock directly (without setup scripts), no particular variant specified"
+[tasks."build-linux_64_"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_.yaml"
+description = "Build importlib_metadata-feedstock with variant linux_64_ directly (without setup scripts)"
+[tasks."inspect-linux_64_"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_.yaml"
+description = "List contents of importlib_metadata-feedstock packages built for variant linux_64_"
+
+[feature.smithy.dependencies]
+conda-smithy = "*"
+[feature.smithy.tasks.build-locally]
+cmd = "python ./build-locally.py"
+description = "Build packages locally using the same setup scripts used in conda-forge's CI"
+[feature.smithy.tasks.smithy]
+cmd = "conda-smithy"
+description = "Run conda-smithy. Pass necessary arguments."
+[feature.smithy.tasks.rerender]
+cmd = "conda-smithy rerender"
+description = "Rerender the feedstock."
+[feature.smithy.tasks.lint]
+cmd = "conda-smithy lint --conda-forge recipe"
+description = "Lint the feedstock recipe"
+
+[environments]
+smithy = ["smithy"]
+# This is a copy of default, to be enabled by build_steps.sh during Docker builds
+# __PLATFORM_SPECIFIC_ENV__ = []

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -23,7 +23,7 @@ outputs:
     build:
       noarch: python
       script:
-        - uv pip install --python ${{ PYTHON }} . --no-deps
+        - uv pip install --python ${{ PYTHON }} . -vv --no-deps
     requirements:
       host:
         - python ${{ python_min }}.*

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -23,7 +23,9 @@ outputs:
     build:
       noarch: python
       script:
-        - uv pip install --python ${{ PYTHON }} . -vv --no-deps
+        # use uv _with_ default build isolation to avoid circular dependency from 
+        # https://github.com/conda-forge/setuptools_scm-feedstock
+        - uv pip install --python ${{ PYTHON }} . -v --no-deps
     requirements:
       host:
         - python ${{ python_min }}.*

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -29,7 +29,7 @@ outputs:
         - python ${{ python_min }}.*
         - pip
         - setuptools >=61.2
-        - setuptools_scm >=3.4.1
+        - setuptools-scm >=3.4.1
       run:
         - python >=${{ python_min }}
         - zipp >=3.20
@@ -56,7 +56,7 @@ outputs:
             - ${{ python_min }}.*
             - ${{ python_max_check }}.*
       - files:
-          recipe:
+          source:
             - tests/
         requirements:
           run:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -32,7 +32,7 @@ outputs:
         - setuptools_scm >=3.4.1
       run:
         - python >=${{ python_min }}
-        - zipp >=0.5
+        - zipp >=3.20
     tests:
       - python:
           imports: importlib_metadata

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -25,7 +25,7 @@ outputs:
       script:
         # use uv _with_ default build isolation to avoid circular dependency from 
         # https://github.com/conda-forge/setuptools_scm-feedstock
-        - uv pip install --python ${{ PYTHON }} . -v --no-deps
+        - uv pip install --python ${{ PYTHON }} . -v --no-deps --link-mode=copy
     requirements:
       host:
         - python ${{ python_min }}.*

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -23,19 +23,19 @@ outputs:
     build:
       noarch: python
       script:
-        - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --disable-pip-version-check
+        - uv pip install --python ${{ PYTHON }} . --no-deps
     requirements:
       host:
         - python ${{ python_min }}.*
-        - pip
-        - setuptools >=61.2
-        - setuptools-scm >=3.4.1
+        - uv
       run:
         - python >=${{ python_min }}
         - zipp >=3.20
     tests:
       - python:
-          imports: importlib_metadata
+          imports:
+            - importlib_metadata
+            - importlib_metadata._typing
           pip_check: true
           python_version:
             - ${{ python_min }}.*
@@ -50,7 +50,9 @@ outputs:
         - ${{ pin_subpackage("importlib-metadata", exact=True) }}
     tests:
       - python:
-          imports: importlib_metadata
+          imports:
+            - importlib_metadata
+            - importlib_metadata._typing
           pip_check: true
           python_version:
             - ${{ python_min }}.*
@@ -60,11 +62,15 @@ outputs:
             - tests/
         requirements:
           run:
-            - python ${{ python_min }}.*
+            - jaraco.test >=5.4
+            - packaging
+            - pyfakefs
+            - pytest >=6,!=8.1.*
             - pytest-cov
+            - python ${{ python_min }}.*
         script:
           - coverage run --source=importlib_metadata --branch -m pytest -vv --tb=long --color=yes
-          - coverage report --show-missing --skip-covered --fail-under=100
+          - coverage report --show-missing --skip-covered --fail-under=90
 
 about:
   homepage: https://github.com/python/importlib_metadata

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -3,6 +3,7 @@ schema_version: 1
 
 context:
   version: "8.7.0"
+  python_max_check: "3.13"
 
 recipe:
   name: importlib-metadata
@@ -13,7 +14,7 @@ source:
   sha256: d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000
 
 build:
-  number: 0
+  number: 1
   noarch: python
 
 outputs:
@@ -22,13 +23,13 @@ outputs:
     build:
       noarch: python
       script:
-        - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+        - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --disable-pip-version-check
     requirements:
       host:
         - python ${{ python_min }}.*
         - pip
-        - setuptools
-        - setuptools_scm !=6.1.0
+        - setuptools >=61.2
+        - setuptools_scm >=3.4.1
       run:
         - python >=${{ python_min }}
         - zipp >=0.5
@@ -36,7 +37,9 @@ outputs:
       - python:
           imports: importlib_metadata
           pip_check: true
-          python_version: ${{ python_min }}.*
+          python_version:
+            - ${{ python_min }}.*
+            - ${{ python_max_check }}.*
 
   - package:
       name: importlib_metadata
@@ -49,14 +52,25 @@ outputs:
       - python:
           imports: importlib_metadata
           pip_check: true
-          python_version: ${{ python_min }}.*
+          python_version:
+            - ${{ python_min }}.*
+            - ${{ python_max_check }}.*
+      - files:
+          recipe:
+            - tests/
+        requirements:
+          run:
+            - python ${{ python_min }}.*
+            - pytest-cov
+        script:
+          - coverage run --source=importlib_metadata --branch -m pytest -vv --tb=long --color=yes
+          - coverage report --show-missing --skip-covered --fail-under=100
 
 about:
   homepage: https://github.com/python/importlib_metadata
   summary: A library to access the metadata for a Python package
   license: Apache-2.0
   license_file: LICENSE
-  license_family: APACHE
 
 extra:
   feedstock-name: importlib_metadata


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Links:
- for #148
- alternative to #149

Changes:
- [x] use `pixi` for install tool
- [x] use `uv` in `host` to avoid circular dep
- [x] update more deps
- [x] add more tests
