### PR TITLE
Avoid circular dependency from setuptools-scm

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,11 +31,21 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
-mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-%H-%M-%S)
-echo > /opt/conda/conda-meta/history
-micromamba install --root-prefix ~/.conda --prefix /opt/conda \
-    --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  rattler-build conda-forge-ci-setup=4 "conda-build>=24.1"
+curl -fsSL https://pixi.sh/install.sh | bash
+export PATH="~/.pixi/bin:$PATH"
+pushd "${FEEDSTOCK_ROOT}"
+arch=$(uname -m)
+if [[ "$arch" == "x86_64" ]]; then
+  arch="64"
+fi
+sed -i.bak -e "s/platforms = .*/platforms = [\"linux-${arch}\"]/" -e "s/# __PLATFORM_SPECIFIC_ENV__ =/docker-build-linux-$arch =/" pixi.toml
+echo "Creating environment"
+PIXI_CACHE_DIR=/opt/conda pixi install --environment docker-build-linux-$arch
+pixi list
+echo "Activating environment"
+eval "$(pixi shell-hook --environment docker-build-linux-$arch)"
+mv pixi.toml.bak pixi.toml
+popd
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc
@@ -48,9 +58,6 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
-if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${HOST_PLATFORM}" != linux-* ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
-    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --test skip"
-fi
 
 
 ( endgroup "Configuring conda" ) 2> /dev/null

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,18 +1,10 @@
 bot:
   automerge: true
-build_platform:
-  osx_arm64: osx_64
-conda_forge_output_validation: true
 github:
   branch_name: main
   tooling_branch_name: main
-provider:
-  linux: azure
-  linux_aarch64: azure
-  linux_ppc64le: azure
-  osx: azure
-  win: azure
 conda_build:
   pkg_format: '2'
-test: native_and_emulated
 conda_build_tool: rattler-build
+conda_forge_output_validation: true
+conda_install_tool: pixi

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,53 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: toml -*-
+
+#                             VVVVVV  minimum `pixi` version
+"$schema" = "https://pixi.sh/v0.36.0/schema/manifest/schema.json"
+
+[project]
+name = "importlib_metadata-feedstock"
+version = "3.48.1"  # conda-smithy version used to generate this file
+description = "Pixi configuration for conda-forge/importlib_metadata-feedstock"
+authors = ["@conda-forge/importlib_metadata"]
+channels = ["conda-forge"]
+platforms = ["linux-64", "osx-64", "win-64"]
+
+[dependencies]
+conda-build = ">=24.1"
+conda-forge-ci-setup = "4.*"
+rattler-build = "*"
+
+[tasks]
+[tasks.inspect-all]
+cmd = "inspect_artifacts --all-packages"
+description = "List contents of all packages found in rattler-build build directory."
+[tasks.build]
+cmd = "rattler-build build --recipe recipe"
+description = "Build importlib_metadata-feedstock directly (without setup scripts), no particular variant specified"
+[tasks."build-linux_64_"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_.yaml"
+description = "Build importlib_metadata-feedstock with variant linux_64_ directly (without setup scripts)"
+[tasks."inspect-linux_64_"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_.yaml"
+description = "List contents of importlib_metadata-feedstock packages built for variant linux_64_"
+
+[feature.smithy.dependencies]
+conda-smithy = "*"
+[feature.smithy.tasks.build-locally]
+cmd = "python ./build-locally.py"
+description = "Build packages locally using the same setup scripts used in conda-forge's CI"
+[feature.smithy.tasks.smithy]
+cmd = "conda-smithy"
+description = "Run conda-smithy. Pass necessary arguments."
+[feature.smithy.tasks.rerender]
+cmd = "conda-smithy rerender"
+description = "Rerender the feedstock."
+[feature.smithy.tasks.lint]
+cmd = "conda-smithy lint --conda-forge recipe"
+description = "Lint the feedstock recipe"
+
+[environments]
+smithy = ["smithy"]
+# This is a copy of default, to be enabled by build_steps.sh during Docker builds
+# __PLATFORM_SPECIFIC_ENV__ = []

--- a/recipe/no-setuptools-scm.py
+++ b/recipe/no-setuptools-scm.py
@@ -1,0 +1,28 @@
+"""Avoid circular dependency on ``setuptools-scm``."""
+
+import sys
+import os
+import re
+import difflib
+
+from pathlib import Path
+
+UTF8 = {"encoding": "utf-8"}
+SRC_DIR = Path(os.environ["SRC_DIR"])
+PKG_VERSION = os.environ["PKG_VERSION"]
+PYPROJECT = SRC_DIR / "pyproject.toml"
+
+
+def main() -> int:
+    old_text = PYPROJECT.read_text(**UTF8)
+    new_text = old_text.replace('dynamic = ["version"]', f'version = "{PKG_VERSION}"')
+    new_text = re.sub(r'"setuptools[_\-]scm.*?",?', "", new_text)
+    diff = difflib.unified_diff(
+        old_text.splitlines(), new_text.splitlines(), "BEFORE", "AFTER"
+    )
+    print("\n".join(diff))
+    PYPROJECT.write_text(new_text, **UTF8)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -22,21 +22,27 @@ outputs:
     build:
       noarch: python
       script:
-        - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+        - ${{ PYTHON }} ${{ RECIPE_DIR }}/no-setuptools-scm.py
+        - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --disable-pip-version-check
     requirements:
       host:
         - python ${{ python_min }}.*
         - pip
         - setuptools
-        - setuptools_scm !=6.1.0
+        # as this depends on importlib-metadata, is patched out above
+        # - setuptools_scm !=6.1.0
       run:
         - python >=${{ python_min }}
-        - zipp >=0.5
+        - zipp >=3.20
     tests:
       - python:
-          imports: importlib_metadata
+          imports:
+            - importlib_metadata
+            - importlib_metadata._typing
           pip_check: true
-          python_version: ${{ python_min }}.*
+          python_version:
+            - ${{ python_min }}.*
+            - ${{ python_max_check }}.*
 
   - package:
       name: importlib_metadata
@@ -47,16 +53,34 @@ outputs:
         - ${{ pin_subpackage("importlib-metadata", exact=True) }}
     tests:
       - python:
-          imports: importlib_metadata
+          imports:
+            - importlib_metadata
+            - importlib_metadata._typing
           pip_check: true
-          python_version: ${{ python_min }}.*
+          python_version:
+            - ${{ python_min }}.*
+            - ${{ python_max_check }}.*
+      - files:
+          source:
+            - tests/
+        requirements:
+          run:
+            - jaraco.test >=5.4
+            - packaging
+            - pyfakefs
+            - pytest >=6,!=8.1.*
+            - pytest-cov
+            - python ${{ python_min }}.*
+        script:
+          - coverage run --source=importlib_metadata --branch -m pytest -vv --tb=long --color=yes
+          - coverage report --show-missing --skip-covered --fail-under=90
+
 
 about:
   homepage: https://github.com/python/importlib_metadata
   summary: A library to access the metadata for a Python package
   license: Apache-2.0
   license_file: LICENSE
-  license_family: APACHE
 
 extra:
   feedstock-name: importlib_metadata

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -14,7 +14,7 @@ source:
   sha256: d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000
 
 build:
-  number: 0
+  number: 1
   noarch: python
 
 outputs:
@@ -29,7 +29,7 @@ outputs:
       host:
         - python ${{ python_min }}.*
         - pip
-        - setuptools
+        - setuptools >=61.2
         # as this depends on importlib-metadata, is patched out above
         # - setuptools_scm !=6.1.0
       run:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -3,6 +3,7 @@ schema_version: 1
 
 context:
   version: "8.7.0"
+  python_max_check: "3.13"
 
 recipe:
   name: importlib-metadata


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Links:
- for #148
- alternative to #149, #150

Changes:
- [x] use `pixi` for root install
- [x] update build, host deps 
- [x] use script to patch out `setuptools_scm` (which depends on `importlib-metadata`)
- [x] add tests with coverage